### PR TITLE
Make the pattern work with more WhatsApp Versions

### DIFF
--- a/Whatsapp_Group_Chat_Analysis_for_Android.ipynb
+++ b/Whatsapp_Group_Chat_Analysis_for_Android.ipynb
@@ -241,7 +241,7 @@
       },
       "source": [
         "def startsWithDateAndTime(s):\n",
-        "    pattern = '^([0-9]+)(\\/)([0-9]+)(\\/)([0-9]+), ([0-9]+):([0-9]+)[ ]?(AM|PM|am|pm)? -' \n",
+        "    pattern = '^([0-9]+)(\/)([0-9]+)(\/)([0-9]+),? ?([0-9]+):([0-9]+) ?(AM|PM|am|pm|p. m.|a. m.|a.m.|p.m.)? ?-? ?'\n",
         "    result = re.match(pattern, s)\n",
         "    if result:\n",
         "        return True\n",


### PR DESCRIPTION
I changed the regex Patter in the Android version to
`pattern = '^([0-9]+)(\/)([0-9]+)(\/)([0-9]+),? ?([0-9]+):([0-9]+) ?(AM|PM|am|pm|p. m.|a. m.|a.m.|p.m.)? ?-? ?'`

which will detect more version that I encountered.

Also, due to sometimes the a.m and p.m elements having spaces, i used a slight modification of the getDataPoints Function (not in the pull request as still a WIP):

```
def getDataPoint(line):   
    splitLine = line.split(' - ') 
    dateTime = splitLine[0]
    dateTime=dateTime.replace(',', '')
    date_time = dateTime.split(' ') 
    date = date_time[0]
    time =' '.join(date_time[1:]).replace('. m', '.m')
    message = ' '.join(splitLine[1:])
    if FindAuthor(message): 
        splitMessage = message.split(': ') 
        author = splitMessage[0] 
        message = ' '.join(splitMessage[1:])
    else:
        author = None
    return date, time, author, message
```

